### PR TITLE
Java Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM java:8
+RUN mkdir -p /usr/src/service/
+COPY target/*.jar /usr/src/service/app.jar
+WORKDIR /usr/src/service/
+CMD ["java", "-jar", "app.jar"]


### PR DESCRIPTION
This Dockerfile can be used to package a Java 8 application into a container. I'll explain in detail on Monday
